### PR TITLE
Disable unneeded crypto functions to allow mbedTLS to compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-src"
 version = "0.0.0+3.0.0p1"
+source = "git+https://github.com/lkatalin/mbedtls-src?branch=generate_config#47bb068e99dfd6a15814f448eed0336b30b91f82"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -272,7 +273,7 @@ name = "mbedtls-sys"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mbedtls-src 0.0.0+3.0.0p1",
+ "mbedtls-src 0.0.0+3.0.0p1 (git+https://github.com/lkatalin/mbedtls-src?branch=generate_config)",
 ]
 
 [[package]]
@@ -631,6 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum mbedtls-src 0.0.0+3.0.0p1 (git+https://github.com/lkatalin/mbedtls-src?branch=generate_config)" = "<none>"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"

--- a/src/bignum/mod.rs
+++ b/src/bignum/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/cipher/raw/mod.rs
+++ b/src/cipher/raw/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/cipher/raw/serde.rs
+++ b/src/cipher/raw/serde.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/ecp/mod.rs
+++ b/src/ecp/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/kw/mod.rs
+++ b/src/kw/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 use crate::cipher::raw::CipherId;
 use crate::error::{IntoResult, Result};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/pk/dhparam.rs
+++ b/src/pk/dhparam.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/pkcs12/mod.rs
+++ b/src/pkcs12/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/rng/ctr_drbg.rs
+++ b/src/rng/ctr_drbg.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/rng/hmac_drbg.rs
+++ b/src/rng/hmac_drbg.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/rng/mod.rs
+++ b/src/rng/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/rng/os_entropy.rs
+++ b/src/rng/os_entropy.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/rng/rdrand.rs
+++ b/src/rng/rdrand.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/ssl/ciphersuites.rs
+++ b/src/ssl/ciphersuites.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/ssl/config.rs
+++ b/src/ssl/config.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/ssl/context.rs
+++ b/src/ssl/context.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/ssl/ticket.rs
+++ b/src/ssl/ticket.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/wrapper_macros.rs
+++ b/src/wrapper_macros.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/x509/certificate.rs
+++ b/src/x509/certificate.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/x509/crl.rs
+++ b/src/x509/crl.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/x509/csr.rs
+++ b/src/x509/csr.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/x509/mod.rs
+++ b/src/x509/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/x509/profile.rs
+++ b/src/x509/profile.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "vendored"))]
+
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or


### PR DESCRIPTION
This effectively compiles out most of the library (everything except for files related to ECDH) when the `vendored` flag is enabled.

It allows `mbedtls` to compile, even if it's not a long-term solution.