### PR TITLE
Re-enable modules needed for ECDH

### DIFF
--- a/src/bignum/mod.rs
+++ b/src/bignum/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(not(feature = "vendored"))]
 
 /* Copyright (c) Fortanix, Inc.
  *

--- a/src/ecp/mod.rs
+++ b/src/ecp/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(feature = "vendored"))]
-
 /* Copyright (c) Fortanix, Inc.
  *
  * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or

--- a/src/pk/dhparam.rs
+++ b/src/pk/dhparam.rs
@@ -1,4 +1,4 @@
-#![cfg(not(feature = "vendored"))]
+
 
 /* Copyright (c) Fortanix, Inc.
  *

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(not(feature = "vendored"))]
+
 
 /* Copyright (c) Fortanix, Inc.
  *


### PR DESCRIPTION
This should enable all the imports needed for mbedTLS' ECDH functions.